### PR TITLE
Fix UnboundLocalError when clicking twice in tabs bar

### DIFF
--- a/sqlite_bro/sqlite_bro.py
+++ b/sqlite_bro/sqlite_bro.py
@@ -468,12 +468,12 @@ R0lGODdhCAAIAIgAAPAAAP///ywAAAAACAAIAAACDkyAeJYM7FR8Ex7aVpIFADs=
         if "label" in elem:  # and widget.instate(['pressed']):
             index = widget.index("@%d,%d" % (x, y))
             titre = widget.tab(index, 'text')
-        # determine selected table
-        actions = [widget, index]
-        title = 'Changing Tab label'
-        fields = ['', ['current label', (titre), 'r', 30], '',
-                  ['new label', titre, 'w', 30]]
-        create_dialog(title, fields, ("Ok", self.btn_chg_tab_ok), actions)
+            # determine selected table
+            actions = [widget, index]
+            title = 'Changing Tab label'
+            fields = ['', ['current label', (titre), 'r', 30], '',
+                ['new label', titre, 'w', 30]]
+            create_dialog(title, fields, ("Ok", self.btn_chg_tab_ok), actions)
 
     def btn_press(self, event):
             """button press over a widget with a 'close' element"""


### PR DESCRIPTION
Clicking twice in a blank space in tabs bar raises an exception trying to show the "Changing Tab label" dialog:

```
Exception in Tkinter callback
Traceback (most recent call last):
  File "C:\runtimes\Anaconda3_64\Lib\tkinter\__init__.py", line 1705, in __call__
    return self.func(*args)
  File "p:/repos/sqlitebro/sqlitebro.py", line 473, in btn_presstwice
    actions = [widget, index]
UnboundLocalError: local variable 'index' referenced before assignment
```

Fixed as was only to be expected: with one tab :D